### PR TITLE
Improve first contact fetchAndUpsertDevice to make sure data is not overridden

### DIFF
--- a/src/app/device-first-contact.service.ts
+++ b/src/app/device-first-contact.service.ts
@@ -74,11 +74,11 @@ export class DeviceFirstContactService {
     const info = plainToInstance(Info, plainInfo);
     if (!info.macAddress) {
       console.error(
-        `No MAC address returned for address: ${address}`,
+        `Could not retrieve MAC address for device at ${address}. Response:`,
         plainInfo
       );
       throw new Error(
-        `Could not retrieve MAC address for device at ${address}`
+        `Could not retrieve MAC address for device at ${address}. See console for details.`
       );
     }
     const macAddress = info.macAddress;

--- a/src/app/device-first-contact.service.ts
+++ b/src/app/device-first-contact.service.ts
@@ -15,26 +15,103 @@ export class DeviceFirstContactService {
     this.listenToElectronDiscovery();
   }
 
-  async tryCreateDevice(address: string): Promise<DeviceWithState> {
-    console.log(address, 'Trying to create a new device');
-    const plainInfo = await firstValueFrom(this.getDeviceInfo(address));
-    console.log(address, plainInfo);
-    const info = plainToInstance(Info, plainInfo);
-    console.log(address, plainInfo);
-    if (!info.macAddress) {
-      throw Error('No mac address returned');
-    }
+  /**
+   * Creates a new device record in the database.
+   * Assumes the device does not already exist.
+   * @param macAddress - The unique MAC address for the new device.
+   * @param address - The network address (e.g., IP) for the new device.
+   * @returns The newly created device object.
+   */
+  private async _createDevice(
+    macAddress: string,
+    address: string
+  ): Promise<Device> {
+    console.log(
+      `Creating new device entry for MAC: ${macAddress} at address: ${address}`
+    );
     const device: Device = {
-      macAddress: info.macAddress,
+      macAddress: macAddress,
       address: address,
       isHidden: false,
+      // Add other default properties if needed
     };
-    db.devices.put(device);
-    console.log(address, 'Device created');
+    await db.devices.put(device);
+    console.log(`Device created for MAC: ${macAddress}`);
+    return device;
+  }
+
+  /**
+   * Updates the address of an existing device record in the database.
+   * @param device - The existing device object to update.
+   * @param newAddress - The new network address for the device.
+   * @returns The updated device object.
+   */
+  private async _updateDeviceAddress(
+    device: Device,
+    newAddress: string
+  ): Promise<Device> {
+    console.log(
+      `Updating address for device MAC: ${device.macAddress} to ${newAddress}`
+    );
+    device.address = newAddress;
+    await db.devices.put(device); // Assumes put handles updates based on the primary key (macAddress)
+    console.log(`Device address updated for MAC: ${device.macAddress}`);
+    return device;
+  }
+
+  /**
+   * Fetches device information using its address, then ensures a corresponding
+   * device record exists in the database (creating or updating its address
+   * as necessary). Returns the device combined with its latest state info.
+   *
+   * @param address - The network address (e.g., IP) to query.
+   * @returns A Promise resolving to the device (from DB) with its current state info.
+   * @throws Error if device info cannot be fetched or lacks a MAC address.
+   */
+  async fetchAndUpsertDevice(address: string): Promise<DeviceWithState> {
+    console.log(address, 'Trying to create a new device');
+    const plainInfo = await firstValueFrom(this.getDeviceInfo(address));
+    const info = plainToInstance(Info, plainInfo);
+    if (!info.macAddress) {
+      console.error(
+        `No MAC address returned for address: ${address}`,
+        plainInfo
+      );
+      throw new Error(
+        `Could not retrieve MAC address for device at ${address}`
+      );
+    }
+    const macAddress = info.macAddress;
+
+    // Check Database and Create/Update
+    let device: Device;
+    const existingDevice = await db.devices.get(macAddress);
+
+    if (existingDevice) {
+      console.log(`Device found for MAC: ${macAddress}`);
+      // Check if the address needs updating
+      if (existingDevice.address !== address) {
+        device = await this._updateDeviceAddress(existingDevice, address);
+      } else {
+        console.log(
+          `Device address (${address}) is already up-to-date for MAC: ${macAddress}`
+        );
+        device = existingDevice; // No update needed, use existing data
+      }
+    } else {
+      console.log(
+        `No existing device found for MAC: ${macAddress}. Creating new entry.`
+      );
+      device = await this._createDevice(macAddress, address);
+    }
+
+    // 3. Combine DB record with State Info
     const deviceWithState = new DeviceWithState(device);
     deviceWithState.stateInfo = plainToInstance(DeviceStateInfo, {
       info: plainInfo,
     });
+
+    console.log(`Successfully processed device for address: ${address}`);
     return deviceWithState;
   }
 
@@ -50,7 +127,7 @@ export class DeviceFirstContactService {
     console.log('Listening to electron discovery');
     window.electron.onDeviceDiscovered(ipAddress => {
       console.log('Potential device discovered', ipAddress);
-      this.tryCreateDevice(ipAddress);
+      this.fetchAndUpsertDevice(ipAddress);
     });
   }
 }

--- a/src/app/dialog-device-add/dialog-device-add.component.ts
+++ b/src/app/dialog-device-add/dialog-device-add.component.ts
@@ -102,7 +102,7 @@ export class DialogDeviceAddComponent {
     this.currentStep = AddStep.Adding;
     try {
       this.deviceWithState =
-        await this.deviceFirstContactService.tryCreateDevice(address);
+        await this.deviceFirstContactService.fetchAndUpsertDevice(address);
     } catch (error) {
       this.errorMessage = 'Could not add device.';
       console.error(error);


### PR DESCRIPTION
When adding an already existing device previously, all custom data, like device visibility and custom name would be lost.